### PR TITLE
Rollback on elasticsearch indices now works

### DIFF
--- a/joplin.elasticsearch/project.clj
+++ b/joplin.elasticsearch/project.clj
@@ -6,5 +6,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clojurewerkz/elastisch "2.0.0"]
+                 [clojurewerkz/elastisch "2.1.0-beta4"]
                  [joplin.core "0.1.5-SNAPSHOT"]])

--- a/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
+++ b/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
@@ -165,7 +165,7 @@
 
 (defn- drop-index [alias-name & indexes]
   (let [es-client (ensure-connected)]
-    (esi/update-aliases es-client (map #(hash-map :remove {:index % :alias alias-name}) indexes))
+    (esi/update-aliases es-client (map #(hash-map :remove {:index % :aliases alias-name}) indexes))
     (doseq [index indexes]
       (esi/delete es-client index))))
 


### PR DESCRIPTION
Depended on https://github.com/clojurewerkz/elastisch/pull/98 merged in elastisch 2.1.0-beta4
