### PR TITLE
Fixing document id getting lost when running the migrate-data function

### DIFF
--- a/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
+++ b/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
@@ -61,10 +61,9 @@
                        mapping-type
                        :query {:match_all {}})
            (esd/scroll-seq es-client)
-           (map :_source)
-           (map trans-f)
            (pmap (fn [doc]
-                   (esd/create es-client new-index mapping-type doc :id (:_id doc))))))))
+                   (esd/create es-client new-index mapping-type
+                               (trans-f (:_source doc)) :id (:_id doc))))))))
 
 ;; ============================================================================
 ;; Functions for use within migrations


### PR DESCRIPTION
When we map :_source on the document we lost the :_id, so the document we create in the new index has no id.

This PR fixes that.
