### PR TITLE
Cassaforte 2.0.0-beta6

### DIFF
--- a/joplin.cassandra/project.clj
+++ b/joplin.cassandra/project.clj
@@ -6,5 +6,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clojurewerkz/cassaforte "2.0.0-beta4"]
+                 [clojurewerkz/cassaforte "2.0.0-beta6"]
                  [joplin.core "0.1.13-SNAPSHOT"]])


### PR DESCRIPTION
Includes updated Hayt and `cql/iterate-table` fixes (which makes data migration with Joplin possible).
