### PR TITLE
Cassaforte 2.0.0-beta8

### DIFF
--- a/joplin.cassandra/project.clj
+++ b/joplin.cassandra/project.clj
@@ -6,5 +6,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clojurewerkz/cassaforte "2.0.0-beta6"]
+                 [clojurewerkz/cassaforte "2.0.0-beta8"]
                  [joplin.core "0.1.14-SNAPSHOT"]])


### PR DESCRIPTION
Note: there is a [breaking public API change](http://blog.clojurewerkz.org/blog/2014/10/13/cassaforte-2-dot-0-0-beta8-is-released/) that
may affect some migrations but otherwise it's the most solid Cassaforte release to date.

May be worth bumping Joplin to `0.2.0` after merging this.
