### PR TITLE
Coerce the N argument to rollback-db to be an integer

### DIFF
--- a/joplin.core/src/joplin/core.clj
+++ b/joplin.core/src/joplin/core.clj
@@ -124,12 +124,11 @@ or resource folders inside a jar on the classpath"
 
 (defn do-rollback
   "Perform rollback on a database"
-  [migrations db n-str]
+  [migrations db n]
   (println "Rolling back" db)
   (doseq [m migrations]
     (ragtime.core/remember-migration m))
-  (ragtime.core/rollback-last db (or (when n-str (Integer/parseInt n-str))
-                                     1)))
+  (ragtime.core/rollback-last db (or n 1)))
 
 (defn do-seed-fn
   "Run a seeder function with migration check"

--- a/joplin.core/src/joplin/main.clj
+++ b/joplin.core/src/joplin/main.clj
@@ -72,7 +72,9 @@ Options:
       "migrate"  (run-op migrate-db targets clean-args)
       "seed"     (run-op seed-db targets clean-args)
 
-      "rollback" (apply rollback-db (first targets) clean-args)
+      "rollback" (apply rollback-db (first targets)
+                        (when (not-empty clean-args)
+                          (cons (Integer/parseInt (first clean-args)) (rest clean-args))))
       "reset"    (apply reset-db (first targets) clean-args)
       "create"   (apply create-migration (first targets) clean-args)
 


### PR DESCRIPTION
do-rollback was expecting a string argument as the number of migrations to roll back.  This was fine when passing arguments from the lein plugin, but made calling it directly awkward.
