### PR TITLE
Pass argument map instead 2 args

### DIFF
--- a/joplin.cassandra/src/joplin/cassandra/database.clj
+++ b/joplin.cassandra/src/joplin/cassandra/database.clj
@@ -37,7 +37,7 @@
     (ensure-migration-schema (get-connection hosts keyspace))
     (cql/delete (get-connection hosts keyspace)
                 "migrations"
-                (cq/where :id id)))
+                (cq/where {:id id})))
 
   (applied-migration-ids [db]
     (ensure-migration-schema (get-connection hosts keyspace))


### PR DESCRIPTION
Fixed error when trying to rerun reset-db with cassandra target
