### PR TITLE
Fixing java.classpath deps version

### DIFF
--- a/joplin.core/project.clj
+++ b/joplin.core/project.clj
@@ -6,6 +6,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/java.classpath "0.2.3-SNAPSHOT"]
+                 [org.clojure/java.classpath "0.2.2"]
                  [clj-time "0.8.0"]
                  [ragtime/ragtime.core "0.3.8"]])


### PR DESCRIPTION
It got swept up with the version bump of joplin in a35b0e6
