### PR TITLE
multiple paths for ragtime type SQL migrations

### DIFF
--- a/joplin.jdbc/src/joplin/jdbc/database.clj
+++ b/joplin.jdbc/src/joplin/jdbc/database.clj
@@ -30,9 +30,10 @@
        (sort-by :id)
        (map verbose-migration)))
 
-(defn- get-sql-migrations [path]
-  (let [migrations (get-sql-migrations' path)]
-    (when (empty? migrations)
+(defn- get-sql-migrations [paths]
+  (let [paths (if (sequential? paths) paths [paths])
+        migrations (flatten (map get-sql-migrations' paths))]
+    (when (some empty? migrations)
       (println "Warning, no migrators found!"))
     migrations))
 


### PR DESCRIPTION
I have come across a situation where I want to have migrations from multiple sources all applied to one database, which was not possible due to the default strategy ragtime uses (raise-error). This should work satisfactory as long as the paths always comes in the same order.