### PR TITLE
jdbc: support for multiple migration-tables

### DIFF
--- a/example/joplin/migrators/jdbc/extrapath/0001.clj
+++ b/example/joplin/migrators/jdbc/extrapath/0001.clj
@@ -1,0 +1,12 @@
+(ns migrators.jdbc.extrapath.0001
+  (:use [clojure.java.jdbc :as sql]
+        [joplin.jdbc.database]))
+
+(defn up [db]
+  (sql/with-connection db
+    (sql/create-table :test_table_2
+                      [:id "INT"])))
+
+(defn down [db]
+  (sql/with-connection db
+    (sql/drop-table :test_table_2)))

--- a/example/joplin/migrators/sql/extrapath/0001.down.sql
+++ b/example/joplin/migrators/sql/extrapath/0001.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE test_table_2;

--- a/example/joplin/migrators/sql/extrapath/0001.up.sql
+++ b/example/joplin/migrators/sql/extrapath/0001.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE test_table_2 (id INT);

--- a/example/project.clj
+++ b/example/project.clj
@@ -13,8 +13,10 @@
   :joplin {:migrators {:es-mig           "joplin/migrators/es"
                        :es-data-mig      "joplin/migrators/esdata"
                        :sql-mig          "joplin/migrators/sql"
+                       :sql-mig-extra    "joplin/migrators/sql/extrapath"
                        :imported-sql-mig "resources/imported-migrators/sql"
                        :jdbc-mig         "joplin/migrators/jdbc"
+                       :jdbc-mig-extra   "joplin/migrators/jdbc/extrapath"
                        :hive-mig         "joplin/migrators/hive"
                        :cass-mig         "joplin/migrators/cass"
                        :dt-mig           "joplin/migrators/datomic"}
@@ -27,10 +29,12 @@
 
   :profiles {:dev
              {:joplin
-              {:databases    {:dt-dev  {:type :dt, :url ~(str "datomic:free://" TARGET-HOST ":4334/test")}
-                              :sql-dev {:type :sql, :url "jdbc:h2:file:dev"}}
+              {:databases    {:dt-dev        {:type :dt, :url ~(str "datomic:free://" TARGET-HOST ":4334/test")}
+                              :sql-dev       {:type :sql, :url "jdbc:h2:file:dev"}
+                              :sql-dev-extra {:type :sql, :migration-table "ragtime_migrations_extra", :url "jdbc:h2:mem:test"}}
                :environments {:dev [{:db :dt-dev, :migrator :dt-mig, :seed :dt-seed}
-                                    {:db :sql-dev, :migrator :imported-sql-mig, :seed :imported-sql-seed}]}}}
+                                    {:db :sql-dev, :migrator :imported-sql-mig, :seed :imported-sql-seed}
+                                    {:db :sql-dev-extra, :migrator :sql-mig-extra}]}}}
 
              :web-frontend
              {:dependencies [[postgresql/postgresql "9.3-1101.jdbc4"]]
@@ -50,12 +54,14 @@
              :analysis
              {:dependencies [[com.h2database/h2 "1.3.171"]]
               :joplin
-              {:databases    {:cass-dev {:type :cass, :hosts [~TARGET-HOST], :keyspace "test"}
-                              :jdbc-dev {:type :jdbc, :url "jdbc:h2:file:analysis"}
-                              :zk-dev   {:type :zk, :host ~TARGET-HOST, :port 2181, :client :curator}
-                              :zk-prod  {:type :zk, :host "zk-prod", :port 2181, :client :exhibitor}}
+              {:databases    {:cass-dev       {:type :cass, :hosts [~TARGET-HOST], :keyspace "test"}
+                              :jdbc-dev       {:type :jdbc, :url "jdbc:h2:file:analysis"}
+                              :jdbc-dev-extra {:type :jdbc, :migration-table "ragtime_migrations_extra", :url "jdbc:h2:file:analysis"}
+                              :zk-dev         {:type :zk, :host ~TARGET-HOST, :port 2181, :client :curator}
+                              :zk-prod        {:type :zk, :host "zk-prod", :port 2181, :client :exhibitor}}
                :environments {:dev  [{:db :cass-dev, :migrator :cass-mig, :seed :cass-seed}
                                      {:db :jdbc-dev, :migrator :jdbc-mig, :seed :sql-seed}
+                                     {:db :jdbc-dev-extra, :migrator :jdbc-mig-extra, :seed :sql-seed}
                                      {:db :zk-dev, :seed :zk-seed}]
                               :prod [{:db :zk-prod}]}}}
 

--- a/joplin.jdbc/src/joplin/jdbc/database.clj
+++ b/joplin.jdbc/src/joplin/jdbc/database.clj
@@ -1,13 +1,64 @@
+(ns joplin.jdbc.tmp)
+
 (ns joplin.jdbc.database
   (:use [joplin.core])
   (:require [clojure.java.io :as io]
-            [clojure.java.jdbc :as sql]
-            [ragtime.core :as ragtime]
-            [ragtime.sql.database :refer [map->SqlDatabase]]
-            [ragtime.sql.files]))
+            [ragtime.core :as ragtime :refer [Migratable connection]]
+            [ragtime.sql.files])
+  (:import java.io.FileNotFoundException
+           java.util.Date
+           java.text.SimpleDateFormat))
+
+(defn require-jdbc [ns-alias]
+  (try
+    (require 'clojure.java.jdbc.deprecated)
+    (alias ns-alias 'clojure.java.jdbc.deprecated)
+    (catch FileNotFoundException ex
+      (require 'clojure.java.jdbc)
+      (alias ns-alias 'clojure.java.jdbc))))
+
+(require-jdbc 'sql)
+
 
 (def run-sql-fn @#'ragtime.sql.files/run-sql-fn)
 (def migration-pattern @#'ragtime.sql.files/migration-pattern)
+
+(def ^:dynamic *migration-table* "ragtime_migrations")
+
+(defn ^:internal ensure-migrations-table-exists [db]
+  ;; TODO: is there a portable way to detect table existence?
+  (sql/with-connection db
+    (try
+      (sql/create-table *migration-table*
+                        [:id "varchar(255)"]
+                        [:created_at "varchar(32)"])
+      (catch Exception _))))
+
+(defn format-datetime [dt]
+  (-> (SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss.SSS")
+      (.format dt)))
+
+(defrecord SqlDatabase []
+  Migratable
+  (add-migration-id [db id]
+    (sql/with-connection db
+      (ensure-migrations-table-exists db)
+      (sql/insert-values *migration-table*
+                         [:id :created_at]
+                         [(str id) (format-datetime (Date.))])))
+
+  (remove-migration-id [db id]
+    (sql/with-connection db
+      (ensure-migrations-table-exists db)
+      (sql/delete-rows *migration-table* ["id = ?" id])))
+
+  (applied-migration-ids [db]
+    (sql/with-connection db
+      (ensure-migrations-table-exists db)
+      (sql/with-query-results results
+        [(str "SELECT id FROM " *migration-table* " ORDER BY created_at")]
+        (vec (map :id results))))))
+
 
 (defn- migration? [[_ filename]]
   (re-find migration-pattern filename))
@@ -16,9 +67,9 @@
   (second (re-find migration-pattern filename)))
 
 (defn- make-migration [[id [[down _] [up _]]]]
-    {:id   id
-     :up   (run-sql-fn up)
-     :down (run-sql-fn down)})
+  {:id   id
+   :up   (run-sql-fn up)
+   :down (run-sql-fn down)})
 
 (defn- get-sql-migrations' [path]
   (->> path
@@ -36,27 +87,34 @@
       (println "Warning, no migrators found!"))
     migrations))
 
-(defn- get-db [target]
-  (ragtime/connection (get-in target [:db :url])))
-
 ;; ============================================================================
 ;; SQL driven sql migrations, ragtime style
 
+(defn- get-table [target]
+  (or (get-in target [:db :migration-table]) "ragtime_migrations"))
+
+(defn- get-db [target]
+  (map->SqlDatabase {:connection-uri (get-in target [:db :url])}))
+
 (defmethod migrate-db :sql [target & args]
-  (do-migrate (get-sql-migrations (:migrator target)) (get-db target)))
+  (binding [*migration-table* (get-table target)]
+    (do-migrate (get-sql-migrations (:migrator target)) (get-db target))))
 
 (defmethod rollback-db :sql [target & [n]]
-  (do-rollback (get-sql-migrations (:migrator target))
-               (get-db target)
-               n))
+  (binding [*migration-table* (get-table target)]
+    (do-rollback (get-sql-migrations (:migrator target))
+                 (get-db target)
+                 n)))
 
 (defmethod seed-db :sql [target & args]
-  (let [migrations (get-sql-migrations (:migrator target))]
-    (do-seed-fn migrations (get-db target) target args)))
+  (binding [*migration-table* (get-table target)]
+    (let [migrations (get-sql-migrations (:migrator target))]
+      (do-seed-fn migrations (get-db target) target args))))
 
 (defmethod reset-db :sql [target & args]
-  (do-reset (get-sql-migrations (:migrator target))
-            (get-db target) target args))
+  (binding [*migration-table* (get-table target)]
+    (do-reset (get-sql-migrations (:migrator target))
+              (get-db target) target args)))
 
 (defmethod create-migration :sql [target & [id]]
   (let [migration-id (get-full-migrator-id id)
@@ -74,21 +132,25 @@
   (assoc target :connection-uri (get-in target [:db :url])))
 
 (defmethod migrate-db :jdbc [target & args]
-  (do-migrate (get-migrations (:migrator target))
-              (map->SqlDatabase (append-uri target))))
+  (binding [*migration-table* (get-table target)]
+    (do-migrate (get-migrations (:migrator target))
+                (map->SqlDatabase (append-uri target)))))
 
 (defmethod rollback-db :jdbc [target & [n]]
-  (do-rollback (get-migrations (:migrator target))
-               (map->SqlDatabase (append-uri target)) n))
+  (binding [*migration-table* (get-table target)]
+    (do-rollback (get-migrations (:migrator target))
+                 (map->SqlDatabase (append-uri target)) n)))
 
 (defmethod seed-db :jdbc [target & args]
-  (let [migrations (get-migrations (:migrator target))]
-    (do-seed-fn migrations (map->SqlDatabase (append-uri target))
-                target args)))
+  (binding [*migration-table* (get-table target)]
+    (let [migrations (get-migrations (:migrator target))]
+      (do-seed-fn migrations (map->SqlDatabase (append-uri target))
+                  target args))))
 
 (defmethod reset-db :jdbc [target & args]
-  (do-reset (get-migrations (:migrator target))
-            (map->SqlDatabase (append-uri target)) target args))
+  (binding [*migration-table* (get-table target)]
+    (do-reset (get-migrations (:migrator target))
+              (map->SqlDatabase (append-uri target)) target args)))
 
 (defmethod create-migration :jdbc [target & [id]]
   (do-create-migration target id "joplin.jdbc.database"))


### PR DESCRIPTION
Support for multiple migration-tables. Had to copy code from ragtime since the code doesn't allow for rebinding the migration-table variable as it's hardcoded in one of the SQL queries in the ragtime library. A PR has been done by @martintrojer to remedy that.