### PR TITLE
Corrects documentation for DB type for Cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Provided database types and their respective plugins;
     <td>joplin.dt.database</td>
   </tr>
   <tr>
-    <td>:dt</td>
+    <td>:cass</td>
     <td>joplin.cassandra.database</td>
   </tr>
 </table>


### PR DESCRIPTION
I noticed this when trying to set up my project with Cassandra.