### PR TITLE
Prevent connection leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Provided database types and their respective plugins;
     <td>joplin.dt.database</td>
   </tr>
   <tr>
-    <td>:dt</td>
+    <td>:cass</td>
     <td>joplin.cassandra.database</td>
   </tr>
 </table>

--- a/joplin.cassandra/src/joplin/cassandra/database.clj
+++ b/joplin.cassandra/src/joplin/cassandra/database.clj
@@ -19,8 +19,7 @@
     (catch AlreadyExistsException e)))
 
 (defn get-connection [hosts keyspace]
-  (when-let [conn (cc/connect hosts)]
-    (cql/use-keyspace conn keyspace)
+  (when-let [conn (cc/connect hosts keyspace)]
     conn))
 
 ;; ============================================================================

--- a/joplin.cassandra/src/joplin/cassandra/database.clj
+++ b/joplin.cassandra/src/joplin/cassandra/database.clj
@@ -19,8 +19,13 @@
     (catch AlreadyExistsException e)))
 
 (defn get-connection [hosts keyspace]
+  (cc/connect hosts keyspace))
+
+(defn with-connection [hosts keyspace f]
   (when-let [conn (cc/connect hosts keyspace)]
-    conn))
+    (try
+      (f conn)
+      (finally (cc/disconnect! conn)))))
 
 ;; ============================================================================
 ;; Ragtime interface
@@ -28,22 +33,28 @@
 (defrecord CassandraDatabase [hosts keyspace]
   Migratable
   (add-migration-id [db id]
-    (ensure-migration-schema (get-connection hosts keyspace))
-    (cql/insert (get-connection hosts keyspace)
-                "migrations"
-                {:id id, :created_at (java.util.Date.)}))
+    (with-connection hosts keyspace
+      (fn [conn]
+        (ensure-migration-schema conn)
+        (cql/insert conn
+                    "migrations"
+                    {:id id, :created_at (java.util.Date.)}))))
   (remove-migration-id [db id]
-    (ensure-migration-schema (get-connection hosts keyspace))
-    (cql/delete (get-connection hosts keyspace)
-                "migrations"
-                (cq/where {:id id})))
+    (with-connection hosts keyspace
+      (fn [conn]
+        (ensure-migration-schema conn)
+        (cql/delete conn
+                    "migrations"
+                    (cq/where {:id id})))))
 
   (applied-migration-ids [db]
-    (ensure-migration-schema (get-connection hosts keyspace))
-    (->> (cql/select (get-connection hosts keyspace)
-                     "migrations")
-         (sort-by :created_at)
-         (map :id))))
+    (with-connection hosts keyspace
+      (fn [conn]
+        (ensure-migration-schema conn)
+        (->> (cql/select conn
+                         "migrations")
+             (sort-by :created_at)
+             (map :id))))))
 
 (defn- ->CassDatabase [target]
   (map->CassandraDatabase (select-keys (:db target) [:hosts :keyspace])))


### PR DESCRIPTION
If you migrate a Cassandra database from within code, each operation creates a new Cassandra cluster, which generates a lot of threads.

Repro:

1. Open a repl
2. Run
```
(dotimes [_ 10]
    (joplin/migrate-db
     {:db {:type :cass, :hosts ["127.0.0.1"], :keyspace "test-keyspace"}
      :migrator "joplin/migrators/cass"}
     )
    (Thread/sleep 1000))
```
3. Inspect the number of threads

I've left the `get-connection` function since removing it would break backwards compatibility, but I have added the `with-connection` function and changed `CassandraDatabase` to use it.

