### PR TITLE
Make rollback work for datomic

### DIFF
--- a/example/project.clj
+++ b/example/project.clj
@@ -4,9 +4,9 @@
 ;; check ES
 ;; http://192.168.59.103:9200/users/_search?pretty=true&q=*:*
 
-(defproject joplin-example "0.2.13"
+(defproject joplin-example "0.2.14"
   :dependencies [[org.clojure/clojure "1.6.0"]]
-  :plugins [[joplin.lein "0.2.13"]]
+  :plugins [[joplin.lein "0.2.14"]]
 
   :source-paths ["src" "joplin"]
 

--- a/joplin.cassandra/project.clj
+++ b/joplin.cassandra/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.cassandra "0.2.13"
+(defproject joplin.cassandra "0.2.14"
   :description "Cassandra support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -7,4 +7,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clojurewerkz/cassaforte "2.0.0"]
-                 [joplin.core "0.2.13"]])
+                 [joplin.core "0.2.14"]])

--- a/joplin.core/project.clj
+++ b/joplin.core/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.core "0.2.13"
+(defproject joplin.core "0.2.14"
   :description "Flexible datastore migration and seeding"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"

--- a/joplin.datomic/project.clj
+++ b/joplin.datomic/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.datomic "0.2.13"
+(defproject joplin.datomic "0.2.14"
   :description "Datomic support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -7,4 +7,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [com.datomic/datomic-free "0.9.5130"]
-                 [joplin.core "0.2.13"]])
+                 [joplin.core "0.2.14"]])

--- a/joplin.datomic/src/joplin/datomic/database.clj
+++ b/joplin.datomic/src/joplin/datomic/database.clj
@@ -50,11 +50,11 @@
   (remove-migration-id [db id]
     (when-let [conn (get-connection (:url db))]
       (ensure-migration-schema conn)
-      (when-let [mig (first (d/q '[:find ?e
-                                   :in $ ?id
-                                   :where
-                                   [?e :migrations/id ?id]]
-                                 (d/db conn) id))]
+      (when-let [mig (d/q '[:find ?e .
+                            :in $ ?id
+                            :where
+                            [?e :migrations/id ?id]]
+                          (d/db conn) id)]
         @(d/transact conn [[:db.fn/retractEntity mig]]))))
   (applied-migration-ids [db]
     (when-let [conn (get-connection (:url db))]

--- a/joplin.elasticsearch/project.clj
+++ b/joplin.elasticsearch/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.elasticsearch "0.2.13"
+(defproject joplin.elasticsearch "0.2.14"
   :description "ElasticSearch support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -7,5 +7,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [clojurewerkz/elastisch "2.1.0"]
-                 [joplin.core "0.2.13"]
+                 [joplin.core "0.2.14"]
                  [clj-time "0.9.0"]])

--- a/joplin.hive/project.clj
+++ b/joplin.hive/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.hive "0.2.13"
+(defproject joplin.hive "0.2.14"
   :description "Hive Avro support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -11,4 +11,4 @@
                  [org.apache.hive/hive-exec "0.13.0"]
                  [org.apache.hive/hive-jdbc "0.13.0"]
                  [commons-io/commons-io "2.4"]
-                 [joplin.core "0.2.13"]])
+                 [joplin.core "0.2.14"]])

--- a/joplin.jdbc/project.clj
+++ b/joplin.jdbc/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.jdbc "0.2.13"
+(defproject joplin.jdbc "0.2.14"
   :description "JDBC support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -6,5 +6,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [joplin.core "0.2.13"]
+                 [joplin.core "0.2.14"]
                  [ragtime/ragtime "0.3.8"]])

--- a/joplin.lein/project.clj
+++ b/joplin.lein/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.lein "0.2.13"
+(defproject joplin.lein "0.2.14"
   :description "Joplin Leiningen plugin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"

--- a/joplin.zookeeper/project.clj
+++ b/joplin.zookeeper/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin.zookeeper "0.2.13"
+(defproject joplin.zookeeper "0.2.14"
   :description "ZooKeeper support for Joplin"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -10,5 +10,5 @@
                  [org.apache.zookeeper/zookeeper "3.4.6" :exclusions [commons-codec com.sun.jmx/jmxri
                                                                       com.sun.jdmk/jmxtools javax.jms/jms
                                                                       org.slf4j/slf4j-log4j12 log4j]]
-                 [joplin.core "0.2.13"]
+                 [joplin.core "0.2.14"]
                  [curator "0.0.2"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject joplin "0.2.13"
+(defproject joplin "0.2.14"
   :description "Flexible datastore migration and seeding"
   :url "http://github.com/juxt/joplin"
   :scm {:name "git"
@@ -6,7 +6,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [joplin.core "0.2.13"]]
+                 [joplin.core "0.2.14"]]
   :plugins [[lein-sub "0.3.0"]]
   :sub ["joplin.core" "joplin.jdbc" "joplin.elasticsearch" "joplin.zookeeper"
         "joplin.datomic" "joplin.cassandra" "joplin.hive" "joplin.lein"])


### PR DESCRIPTION
This patch fixes a bug in the datalog query used in `remove-migration-id` for datomic which caused `rollback-db` not to work at all for datomic databases.