### PR TITLE
Allow arbitrary keys in ElasticSearchDatabase, giving agnosticism over

### DIFF
--- a/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
+++ b/joplin.elasticsearch/src/joplin/elasticsearch/database.clj
@@ -260,8 +260,7 @@
     (es-get-applied-migrations (client db) (get-migration-index db))))
 
 (defn ->ESDatabase [target]
-  (map->ElasticSearchDatabase (select-keys (merge target (:db target))
-                                           [:host :port :index :migration-index :cluster :native-port])))
+  (map->ElasticSearchDatabase (merge target (:db target))))
 
 ;; ============================================================================
 ;; Joplin interface


### PR DESCRIPTION
ES client used to perform migrations. Closes #66