### PR TITLE
Remove joplin.lein from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Joplin is built on top of [ragtime](https://github.com/weavejester/ragtime).
 * joplin.elasticsearch - migrate and seed [Elasticsearch](http://elasticsearch.org) clusters
 * joplin.hive - migrate and seed [Hive](https://hive.apache.org) tables using Avro
 * joplin.jdbc - migrate and seed SQL databases with jdbc
-* joplin.lein - a leiningen plugin run migrations and seeds
 * joplin.zookeeper - seed [Zookeeper](http://zookeeper.apache.org) clusters
 
 ## Installation


### PR DESCRIPTION
The code for joplin.lein was removed from master, and the
current strategy is to define simple aliases as suggested in
the README, so the joplin.lein plugin should be removed from
README