### PR TITLE
Fix lein tasks for leiningen 2.5.2

### DIFF
--- a/joplin.lein/src/leiningen/joplin.clj
+++ b/joplin.lein/src/leiningen/joplin.clj
@@ -1,5 +1,6 @@
 (ns leiningen.joplin
   (:require [leinjacker.deps :as deps])
+  (:require [leiningen.core.main :refer [leiningen-version]])
   (:use [leiningen.run :only (run)]))
 
 (def version "0.2.15")
@@ -53,8 +54,10 @@
         databases    (-> project :joplin :databases)
         migrators    (-> project :joplin :migrators)
         seeds        (-> project :joplin :seeds)
-        project      (add-joplin-deps project)]
+        project      (add-joplin-deps project)
+        prefix       (when (re-find #"^2.5.2-" (leiningen-version)) "--quote-args")]
     (apply run project
+           prefix
            "-m" "joplin.main"
            "-r" (get-require-string (get-db-types project))
            "-e" environments


### PR DESCRIPTION
Leiningen 2.5.2 introduced a change in args handling, so we need to pass
--quote-args as the first argument

Fixes #68