### PR TITLE
Fix lein tasks

### DIFF
--- a/joplin.lein/src/leiningen/joplin.clj
+++ b/joplin.lein/src/leiningen/joplin.clj
@@ -55,13 +55,15 @@
         migrators    (-> project :joplin :migrators)
         seeds        (-> project :joplin :seeds)
         project      (add-joplin-deps project)
-        prefix       (when (re-find #"^2.5.2-" (leiningen-version)) "--quote-args")]
-    (apply run project
-           prefix
-           "-m" "joplin.main"
-           "-r" (get-require-string (get-db-types project))
-           "-e" environments
-           "-d" databases
-           "-m" migrators
-           "-s" seeds
-           command args)))
+        run-args     (concat
+                       (when (re-find #"^2.5.2" (leiningen-version))
+                         ["--quote-args"])
+                       ["-m" "joplin.main"
+                        "-r" (get-require-string (get-db-types project))
+                        "-e" environments
+                        "-d" databases
+                        "-m" migrators
+                        "-s" seeds
+                        command]
+                       args)]
+    (apply run project run-args)))


### PR DESCRIPTION
The previous fix for lein 2.5.2 introduced 2 new bugs :/

- The lein version specifier was "2.5.2-" instead of "2.5.2", so it only worked with 2.5.2-SNAPSHOT but not on 2.5.2

- For lein 2.5.1 a nil param was being passed as first argument to run, so it was interpreted as `lein run`, executing the main function