### PR TITLE
Remove duplicate SQL migrations...

### DIFF
--- a/joplin.jdbc/src/joplin/jdbc/database.clj
+++ b/joplin.jdbc/src/joplin/jdbc/database.clj
@@ -13,10 +13,25 @@
         (merge uri)
         (merge target))))
 
+(defn- remove-duplicates
+  "Remove duplicates that can occur when working with checked out dependencies"
+  [migrations]
+  (loop [[migration & migrations] migrations
+         added? #{}
+         out []]
+    (if (nil? migration)
+      out
+      (if (get added? (:id migration))
+        (recur migrations added? out)
+        (recur migrations
+               (conj added? (:id migration))
+               (conj out migration))))))
+
 (defn- get-sql-migrations [path]
-  (or (seq (load-directory path))
-      (seq (load-resources path))
-      (seq (load-resources (drop-first-part path "/")))))
+  (remove-duplicates
+   (or (seq (load-directory path))
+       (seq (load-resources path))
+       (seq (load-resources (drop-first-part path "/"))))))
 
 ;; ============================================================================
 ;; SQL driven sql migrations, ragtime style


### PR DESCRIPTION
that can occur when working with checked out dependencies.