### PR TITLE
regex fix applies to all leiningen versions 2.5.2+

### DIFF
--- a/joplin.lein/src/leiningen/joplin.clj
+++ b/joplin.lein/src/leiningen/joplin.clj
@@ -56,7 +56,7 @@
         seeds        (-> project :joplin :seeds)
         project      (add-joplin-deps project)
         run-args     (concat
-                       (when (re-find #"^2.5.2" (leiningen-version))
+                       (when (re-find #"^2.5.(?:[1-9][0-9]+|[2-9])" (leiningen-version))
                          ["--quote-args"])
                        ["-m" "joplin.main"
                         "-r" (get-require-string (get-db-types project))


### PR DESCRIPTION
...rather than just 2.5.2

fixes https://github.com/juxt/joplin/issues/68

Note the regex will be broken again at 2.6, but at least it won't break again at 2.5.4.