### PR TITLE
migration from cassaforte to alia and hayt

### DIFF
--- a/joplin.cassandra/project.clj
+++ b/joplin.cassandra/project.clj
@@ -7,4 +7,5 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [joplin.core "0.3.9-SNAPSHOT"]
-                 [clojurewerkz/cassaforte "2.0.2"]])
+                 [cc.qbits/alia "3.1.10"]
+                 [cc.qbits/hayt "3.2.0"]])


### PR DESCRIPTION
For compatibility with both cassandra 2.x and cassandra 3.x, using alia and hayt.