### PR TITLE
Use Aero's `read-string` to replace `load-string`

### DIFF
--- a/joplin.core/project.clj
+++ b/joplin.core/project.clj
@@ -9,4 +9,5 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.classpath "0.2.3"]
                  [clj-time "0.12.0"]
-                 [ragtime/ragtime.core "0.6.3"]])
+                 [ragtime/ragtime.core "0.6.3"]
+                 [aero "1.0.3"]])

--- a/joplin.core/src/joplin/repl.clj
+++ b/joplin.core/src/joplin/repl.clj
@@ -2,7 +2,8 @@
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [joplin.core :refer [migrate-db rollback-db seed-db pending-migrations
-                                 create-migration]])
+                                 create-migration]]
+            [aero.core :refer [read-config]])
   (:import [java.io PushbackReader]))
 
 (def ^:const libs
@@ -43,11 +44,7 @@
 (defn- run-op [f targets args] (doseq [t targets] (apply f t args)))
 
 (defn load-config [r]
-  (edn/read {:readers {'env (fn [x] (System/getenv (str x)))
-                       'envf (fn [[fmt & args]]
-                               (apply format fmt
-                                      (map #(System/getenv (str %)) args)))}}
-            (PushbackReader. (io/reader r))))
+  (read-config r))
 
 (defn migrate [conf env & args]
   (require-joplin-ns conf)


### PR DESCRIPTION
This commit is fairly rudimentary, I expect there to be feedback and tests. `lein sub install` currently doesn't seem to work:

```
# lein sub install                                                                                                         
Reading project from joplin.jdbc
Could not find artifact joplin.core:joplin.core:jar:0.3.10-SNAPSHOT in clojars (https://clojars.org/repo/)
This could be due to a typo in :dependencies or network issues.
If you are behind a proxy, try setting the 'http_proxy' environment variable.
```