### PR TITLE
Cassandra Migrations Cannot Use Authentication

### DIFF
--- a/joplin.cassandra/src/joplin/cassandra/database.clj
+++ b/joplin.cassandra/src/joplin/cassandra/database.clj
@@ -3,8 +3,7 @@
             [qbits.hayt :as hayt]
             [joplin.core :refer :all]
             [ragtime.protocols :refer [DataStore]])
-  (:import com.datastax.driver.core.exceptions.AlreadyExistsException
-           com.datastax.driver.core.SessionManager))
+  (:import com.datastax.driver.core.SessionManager))
 
 ;; =============================================================
 
@@ -25,12 +24,6 @@
 
 (defn get-connection [db]
   (alia/connect (alia/cluster (cluster-configuration db)) (:keyspace db)))
-
-(defn with-connection [db f]
-  (when-let [conn (get-connection db)]
-    (try
-      (f conn)
-      (finally (alia/shutdown conn)))))
 
 ;; ============================================================================
 ;; Ragtime interface


### PR DESCRIPTION
The motivation for this PR is to enable users to write migrations against Cassandra clusters that require authentication.

There are 2 commits. The first enables credentials to be passed through the `joplin.edn` configuration to the Cassandra connection. The second commit ensures that the user's migration code is run against the cluster containing the `migration` table. By creating one cassandra connection at the beginning of the work and using it both for manipulating ragtime's `migration` table and handing it to the user's migration code, it can ensure all side effects are applied to the same cluster.

The need for this second commit arose during testing the authentication work. My migration code (which had to create its own cassandra connection) was erroneously configuring itself via [mount](https://github.com/tolitius/mount) in my development system. It should have instead been using the configuration that joplin had computed.

We can certainly split this PR into 2 if desired!

Thanks for your work on Joplin!

Update: I pushed a 3rd commit that simply removes dead code.