### PR TITLE
Problem: Cassandra configuration doesn't allow for nonstandard ports.

### DIFF
--- a/joplin.cassandra/src/joplin/cassandra/database.clj
+++ b/joplin.cassandra/src/joplin/cassandra/database.clj
@@ -18,8 +18,10 @@
                                                              :primary-key [:id]}))))
 
 (defn- cluster-configuration
-  [{:keys [hosts credentials] :as cass-db}]
+  [{:keys [hosts credentials port] :as cass-db
+    :or {port 9042}}]
   {:contact-points hosts
+   :port port
    :credentials credentials})
 
 (defn get-connection [db]


### PR DESCRIPTION
Change the configuration to respect a `:port` key if provided in the `joplin.edn` file. If it's not provided, simply use the standard port number.