### PR TITLE
Upgrade ragtime to version 0.6.4

### DIFF
--- a/joplin.core/project.clj
+++ b/joplin.core/project.clj
@@ -9,4 +9,4 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/java.classpath "0.2.3"]
                  [clj-time "0.12.0"]
-                 [ragtime/ragtime.core "0.6.3"]])
+                 [ragtime/ragtime.core "0.6.4"]])

--- a/joplin.jdbc/project.clj
+++ b/joplin.jdbc/project.clj
@@ -7,4 +7,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [joplin.core "0.3.12-SNAPSHOT"]
-                 [ragtime/ragtime.jdbc "0.6.3"]])
+                 [ragtime/ragtime.jdbc "0.6.4"]])


### PR DESCRIPTION
Fixes https://github.com/weavejester/ragtime/issues/109

This bug in ragtime means that if you call `joplin.core/rollback-db` with an `n`
that's a string, the migration does not exist in the db, and the db is fully migrated,
it will begin rolling back all migrations.

